### PR TITLE
Add readme to pyproject.toml for PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "cq-sdk"
 dynamic = ["version"]
 description = "Python SDK for cq — shared agent knowledge commons"
+readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }
 dependencies = [


### PR DESCRIPTION
## Summary

- Add missing `readme = "README.md"` to pyproject.toml so PyPI renders the project description

## Test plan

- [x] `make lint` passes
- [x] `make test` — 235 tests pass