### PR TITLE
Add DEVELOPMENT.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Thank you for your interest in contributing to cq. This guide explains how to ge
 
 - **Search for duplicates.** Check [existing issues](https://github.com/mozilla-ai/cq-python/issues) and [open pull requests](https://github.com/mozilla-ai/cq-python/pulls) before starting work.
 - **Discuss major changes first.** Open an issue before starting work on: new features, API changes, architectural changes, breaking changes, or new dependencies. This avoids wasted effort and helps maintainers provide early guidance.
-- **Set up your development environment.** See the [README](README.md) for prerequisites, installation, and how to run tests and linters.
+- **Set up your development environment.** See [DEVELOPMENT.md](DEVELOPMENT.md) for prerequisites, installation, and how to run tests and linters.
 
 ## Making Changes
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,58 @@
+# Development
+
+## Requirements
+
+- Python 3.11+
+- [uv](https://docs.astral.sh/uv/)
+
+## Initial Setup
+
+```bash
+git clone https://github.com/mozilla-ai/cq-python.git
+cd cq-python
+make setup
+```
+
+## Common Tasks
+
+```bash
+make test           # Run all tests.
+make lint           # Run pre-commit hooks (format, lint, detect-secrets).
+make format         # Auto-format Python files.
+make format-check   # Check formatting without modifying files.
+make clean          # Remove fetched files and build artifacts.
+make help           # Show all available targets.
+```
+
+## Clean Rebuild
+
+```bash
+make clean && make test
+```
+
+`make clean` removes fetched protos, the skill prompt, and build artifacts.
+Committed files (generated proto stubs) are not affected.
+
+## Regenerating Protos
+
+After updating `PROTO_VERSION` in the Makefile:
+
+```bash
+make fetch-protos
+make generate
+```
+
+Proto-generated `_pb2.py` files are committed to the repo. They only need
+regeneration when the proto definitions change.
+
+## Updating the Skill Prompt
+
+After updating `SKILL_VERSION` in the Makefile:
+
+```bash
+make clean
+make fetch-skill
+```
+
+The skill prompt (`src/cq/protocol/skill.md`) is committed to the repo
+and ships baked into the PyPI package.


### PR DESCRIPTION
## Summary

- Add DEVELOPMENT.md documenting setup, common tasks, proto regeneration, and skill prompt updates
- Fix CONTRIBUTING.md link to point at DEVELOPMENT.md instead of README

Matches pattern from cq and cq-go repos.

## Test plan

- [x] `make lint` passes
- [x] `make test` — 235 tests pass