### PR TITLE
Route confirm() and flag() by tier instead of requiring local copy

### DIFF
--- a/src/cq/client.py
+++ b/src/cq/client.py
@@ -311,23 +311,30 @@ class Client:
             The confirmed KnowledgeUnit on success, None on transport error.
 
         Raises:
-            RemoteError: If the remote API explicitly rejects the request.
+            RemoteError: If the remote API explicitly rejects the request
+                or returns an unparseable response.
         """
         assert self._http is not None
         try:
             resp = self._http.post(f"/confirm/{unit_id}")
             resp.raise_for_status()
-            data = resp.json()
-            unit_data = data.get("knowledge_unit", data) if isinstance(data, dict) else data
-            return KnowledgeUnit.model_validate(unit_data)
         except httpx.HTTPStatusError as exc:
             raise RemoteError(
                 status_code=exc.response.status_code,
                 detail=exc.response.text,
             ) from exc
-        except (httpx.HTTPError, ValueError, ValidationError):
+        except httpx.HTTPError:
             logger.debug("Remote confirm failed", exc_info=True)
             return None
+        try:
+            data = resp.json()
+            unit_data = data.get("knowledge_unit", data) if isinstance(data, dict) else data
+            return KnowledgeUnit.model_validate(unit_data)
+        except (ValueError, ValidationError) as exc:
+            raise RemoteError(
+                status_code=resp.status_code,
+                detail=f"Invalid response body: {exc}",
+            ) from exc
 
     def _remote_flag(self, unit_id: str, reason: FlagReason) -> KnowledgeUnit | None:
         """Flag a unit on the remote API.
@@ -336,7 +343,8 @@ class Client:
             The flagged KnowledgeUnit on success, None on transport error.
 
         Raises:
-            RemoteError: If the remote API explicitly rejects the request.
+            RemoteError: If the remote API explicitly rejects the request
+                or returns an unparseable response.
         """
         assert self._http is not None
         try:
@@ -345,17 +353,23 @@ class Client:
                 json={"reason": reason.value},
             )
             resp.raise_for_status()
-            data = resp.json()
-            unit_data = data.get("knowledge_unit", data) if isinstance(data, dict) else data
-            return KnowledgeUnit.model_validate(unit_data)
         except httpx.HTTPStatusError as exc:
             raise RemoteError(
                 status_code=exc.response.status_code,
                 detail=exc.response.text,
             ) from exc
-        except (httpx.HTTPError, ValueError, ValidationError):
+        except httpx.HTTPError:
             logger.debug("Remote flag failed", exc_info=True)
             return None
+        try:
+            data = resp.json()
+            unit_data = data.get("knowledge_unit", data) if isinstance(data, dict) else data
+            return KnowledgeUnit.model_validate(unit_data)
+        except (ValueError, ValidationError) as exc:
+            raise RemoteError(
+                status_code=resp.status_code,
+                detail=f"Invalid response body: {exc}",
+            ) from exc
 
 
 def _db_path_from_env() -> Path | None:

--- a/src/cq/client.py
+++ b/src/cq/client.py
@@ -148,41 +148,69 @@ class Client:
         self._store.insert(unit)
         return unit
 
-    def confirm(self, unit_id: str) -> KnowledgeUnit:
+    def confirm(self, unit_id: str, *, tier: Tier = Tier.LOCAL) -> KnowledgeUnit:
         """Confirm a knowledge unit, boosting its confidence.
 
+        Uses tier to determine where to route the confirmation:
+        - LOCAL: operates on local store, forwards to remote if configured.
+        - Non-local (PRIVATE, PUBLIC): routes directly to the remote API.
+
         Raises:
-            KeyError: If the unit is not found locally.
+            KeyError: If the unit cannot be found.
+            RemoteError: If the remote API explicitly rejects the request.
+            RuntimeError: If a non-local tier is specified without a remote API.
         """
-        unit = self._store.get(unit_id)
-        if unit is None:
-            raise KeyError(f"Knowledge unit not found: {unit_id}")
+        if tier == Tier.LOCAL:
+            unit = self._store.get(unit_id)
+            if unit is None:
+                raise KeyError(f"Knowledge unit not found: {unit_id}")
+            confirmed = apply_confirmation(unit)
+            self._store.update(confirmed)
+            if self._http is not None:
+                try:
+                    self._remote_confirm(unit_id)
+                except RemoteError:
+                    logger.debug("Remote rejected confirm for local unit %s", unit_id)
+            return confirmed
 
-        confirmed = apply_confirmation(unit)
-        self._store.update(confirmed)
+        if self._http is None:
+            raise RuntimeError("Cannot confirm non-local unit without remote API configured")
+        result = self._remote_confirm(unit_id)
+        if result is not None:
+            return result
+        raise KeyError(f"Knowledge unit not found on remote: {unit_id}")
 
-        if self._http is not None:
-            self._remote_confirm(unit_id)
-
-        return confirmed
-
-    def flag(self, unit_id: str, reason: FlagReason) -> KnowledgeUnit:
+    def flag(self, unit_id: str, reason: FlagReason, *, tier: Tier = Tier.LOCAL) -> KnowledgeUnit:
         """Flag a knowledge unit, reducing its confidence.
 
+        Uses tier to determine where to route the flag:
+        - LOCAL: operates on local store, forwards to remote if configured.
+        - Non-local (PRIVATE, PUBLIC): routes directly to the remote API.
+
         Raises:
-            KeyError: If the unit is not found locally.
+            KeyError: If the unit cannot be found.
+            RemoteError: If the remote API explicitly rejects the request.
+            RuntimeError: If a non-local tier is specified without a remote API.
         """
-        unit = self._store.get(unit_id)
-        if unit is None:
-            raise KeyError(f"Knowledge unit not found: {unit_id}")
+        if tier == Tier.LOCAL:
+            unit = self._store.get(unit_id)
+            if unit is None:
+                raise KeyError(f"Knowledge unit not found: {unit_id}")
+            flagged = apply_flag(unit, reason)
+            self._store.update(flagged)
+            if self._http is not None:
+                try:
+                    self._remote_flag(unit_id, reason)
+                except RemoteError:
+                    logger.debug("Remote rejected flag for local unit %s", unit_id)
+            return flagged
 
-        flagged = apply_flag(unit, reason)
-        self._store.update(flagged)
-
-        if self._http is not None:
-            self._remote_flag(unit_id, reason)
-
-        return flagged
+        if self._http is None:
+            raise RuntimeError("Cannot flag non-local unit without remote API configured")
+        result = self._remote_flag(unit_id, reason)
+        if result is not None:
+            return result
+        raise KeyError(f"Knowledge unit not found on remote: {unit_id}")
 
     def status(self) -> StoreStats:
         """Return local store statistics."""
@@ -276,17 +304,40 @@ class Client:
             logger.debug("Remote propose unreachable", exc_info=True)
             return False
 
-    def _remote_confirm(self, unit_id: str) -> None:
-        """Confirm a unit on the remote API."""
+    def _remote_confirm(self, unit_id: str) -> KnowledgeUnit | None:
+        """Confirm a unit on the remote API.
+
+        Returns:
+            The confirmed KnowledgeUnit on success, None on transport error.
+
+        Raises:
+            RemoteError: If the remote API explicitly rejects the request.
+        """
         assert self._http is not None
         try:
             resp = self._http.post(f"/confirm/{unit_id}")
             resp.raise_for_status()
-        except httpx.HTTPError:
+            data = resp.json()
+            unit_data = data.get("knowledge_unit", data) if isinstance(data, dict) else data
+            return KnowledgeUnit.model_validate(unit_data)
+        except httpx.HTTPStatusError as exc:
+            raise RemoteError(
+                status_code=exc.response.status_code,
+                detail=exc.response.text,
+            ) from exc
+        except (httpx.HTTPError, ValueError, ValidationError):
             logger.debug("Remote confirm failed", exc_info=True)
+            return None
 
-    def _remote_flag(self, unit_id: str, reason: FlagReason) -> None:
-        """Flag a unit on the remote API."""
+    def _remote_flag(self, unit_id: str, reason: FlagReason) -> KnowledgeUnit | None:
+        """Flag a unit on the remote API.
+
+        Returns:
+            The flagged KnowledgeUnit on success, None on transport error.
+
+        Raises:
+            RemoteError: If the remote API explicitly rejects the request.
+        """
         assert self._http is not None
         try:
             resp = self._http.post(
@@ -294,8 +345,17 @@ class Client:
                 json={"reason": reason.value},
             )
             resp.raise_for_status()
-        except httpx.HTTPError:
+            data = resp.json()
+            unit_data = data.get("knowledge_unit", data) if isinstance(data, dict) else data
+            return KnowledgeUnit.model_validate(unit_data)
+        except httpx.HTTPStatusError as exc:
+            raise RemoteError(
+                status_code=exc.response.status_code,
+                detail=exc.response.text,
+            ) from exc
+        except (httpx.HTTPError, ValueError, ValidationError):
             logger.debug("Remote flag failed", exc_info=True)
+            return None
 
 
 def _db_path_from_env() -> Path | None:

--- a/src/cq/client.py
+++ b/src/cq/client.py
@@ -156,8 +156,10 @@ class Client:
         - Non-local (PRIVATE, PUBLIC): routes directly to the remote API.
 
         Raises:
-            KeyError: If the unit cannot be found.
-            RemoteError: If the remote API explicitly rejects the request.
+            KeyError: If the unit is not found in the local store (LOCAL tier)
+                or if the remote is unreachable (non-local tiers).
+            RemoteError: If the remote API explicitly rejects the request,
+                including HTTP 404/410.
             RuntimeError: If a non-local tier is specified without a remote API.
         """
         if tier == Tier.LOCAL:
@@ -178,7 +180,7 @@ class Client:
         result = self._remote_confirm(unit_id)
         if result is not None:
             return result
-        raise KeyError(f"Knowledge unit not found on remote: {unit_id}")
+        raise KeyError(f"Remote unreachable; cannot confirm unit: {unit_id}")
 
     def flag(self, unit_id: str, reason: FlagReason, *, tier: Tier = Tier.LOCAL) -> KnowledgeUnit:
         """Flag a knowledge unit, reducing its confidence.
@@ -188,8 +190,10 @@ class Client:
         - Non-local (PRIVATE, PUBLIC): routes directly to the remote API.
 
         Raises:
-            KeyError: If the unit cannot be found.
-            RemoteError: If the remote API explicitly rejects the request.
+            KeyError: If the unit is not found in the local store (LOCAL tier)
+                or if the remote is unreachable (non-local tiers).
+            RemoteError: If the remote API explicitly rejects the request,
+                including HTTP 404/410.
             RuntimeError: If a non-local tier is specified without a remote API.
         """
         if tier == Tier.LOCAL:
@@ -210,7 +214,7 @@ class Client:
         result = self._remote_flag(unit_id, reason)
         if result is not None:
             return result
-        raise KeyError(f"Knowledge unit not found on remote: {unit_id}")
+        raise KeyError(f"Remote unreachable; cannot flag unit: {unit_id}")
 
     def status(self) -> StoreStats:
         """Return local store statistics."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -370,7 +370,7 @@ class TestRemoteIntegration:
         httpx_mock.add_exception(httpx.ConnectError("Connection refused"))
 
         c = Client(addr="http://unreachable", local_db_path=tmp_path / "test.db")
-        with pytest.raises(KeyError, match="ku_remote123"):
+        with pytest.raises(KeyError, match="Remote unreachable"):
             c.confirm("ku_remote123", tier=Tier.PRIVATE)
         c.close()
 
@@ -379,7 +379,7 @@ class TestRemoteIntegration:
         httpx_mock.add_exception(httpx.ConnectError("Connection refused"))
 
         c = Client(addr="http://unreachable", local_db_path=tmp_path / "test.db")
-        with pytest.raises(KeyError, match="ku_remote123"):
+        with pytest.raises(KeyError, match="Remote unreachable"):
             c.flag("ku_remote123", FlagReason.STALE, tier=Tier.PRIVATE)
         c.close()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -311,7 +311,11 @@ class TestRemoteIntegration:
             "evidence": {"confidence": 0.6, "confirmations": 2},
             "tier": "TIER_PRIVATE",
         }
-        httpx_mock.add_response(json={"knowledge_unit": confirmed_unit}, status_code=200)
+        httpx_mock.add_response(
+            url="http://test-remote/confirm/ku_remote123",
+            json={"knowledge_unit": confirmed_unit},
+            status_code=200,
+        )
 
         c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
         result = c.confirm("ku_remote123", tier=Tier.PRIVATE)
@@ -330,7 +334,11 @@ class TestRemoteIntegration:
             "flags": [{"reason": "FLAG_REASON_STALE"}],
             "tier": "TIER_PRIVATE",
         }
-        httpx_mock.add_response(json={"knowledge_unit": flagged_unit}, status_code=200)
+        httpx_mock.add_response(
+            url="http://test-remote/flag/ku_remote123",
+            json={"knowledge_unit": flagged_unit},
+            status_code=200,
+        )
 
         c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
         result = c.flag("ku_remote123", FlagReason.STALE, tier=Tier.PRIVATE)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,7 @@ import httpx
 import pytest
 
 from cq.client import Client, RemoteError
-from cq.models import FlagReason
+from cq.models import FlagReason, Tier
 
 
 @pytest.fixture()
@@ -102,6 +102,14 @@ class TestLocalOnlyMode:
         )
         assert ku.context.languages == ["python"]
         assert ku.context.frameworks == ["django"]
+
+    def test_confirm_non_local_without_remote_raises(self, client: Client):
+        with pytest.raises(RuntimeError, match="remote API"):
+            client.confirm("ku_nonexistent", tier=Tier.PRIVATE)
+
+    def test_flag_non_local_without_remote_raises(self, client: Client):
+        with pytest.raises(RuntimeError, match="remote API"):
+            client.flag("ku_nonexistent", FlagReason.STALE, tier=Tier.PRIVATE)
 
     def test_query_language_boosts_ranking(self, client: Client):
         client.propose(
@@ -292,6 +300,107 @@ class TestRemoteIntegration:
 
         results = c.query(["api"])
         assert len(results) == 1
+        c.close()
+
+    def test_confirm_routes_to_remote_for_non_local_tier(self, tmp_path: Path, httpx_mock):
+        """confirm() routes to remote API when tier is non-local."""
+        confirmed_unit = {
+            "id": "ku_remote123",
+            "domain": ["api"],
+            "insight": {"summary": "S", "detail": "D", "action": "A"},
+            "evidence": {"confidence": 0.6, "confirmations": 2},
+            "tier": "TIER_PRIVATE",
+        }
+        httpx_mock.add_response(json={"knowledge_unit": confirmed_unit}, status_code=200)
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        result = c.confirm("ku_remote123", tier=Tier.PRIVATE)
+        assert result.id == "ku_remote123"
+        assert result.evidence.confidence == pytest.approx(0.6)
+        assert result.tier == Tier.PRIVATE
+        c.close()
+
+    def test_flag_routes_to_remote_for_non_local_tier(self, tmp_path: Path, httpx_mock):
+        """flag() routes to remote API when tier is non-local."""
+        flagged_unit = {
+            "id": "ku_remote123",
+            "domain": ["api"],
+            "insight": {"summary": "S", "detail": "D", "action": "A"},
+            "evidence": {"confidence": 0.35},
+            "flags": [{"reason": "FLAG_REASON_STALE"}],
+            "tier": "TIER_PRIVATE",
+        }
+        httpx_mock.add_response(json={"knowledge_unit": flagged_unit}, status_code=200)
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        result = c.flag("ku_remote123", FlagReason.STALE, tier=Tier.PRIVATE)
+        assert result.id == "ku_remote123"
+        assert result.evidence.confidence == pytest.approx(0.35)
+        assert len(result.flags) == 1
+        c.close()
+
+    def test_confirm_raises_remote_error_for_rejected_non_local(self, tmp_path: Path, httpx_mock):
+        """confirm() raises RemoteError when remote rejects a non-local unit."""
+        httpx_mock.add_response(json={"detail": "not found"}, status_code=404)
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        with pytest.raises(RemoteError):
+            c.confirm("ku_remote123", tier=Tier.PRIVATE)
+        c.close()
+
+    def test_flag_raises_remote_error_for_rejected_non_local(self, tmp_path: Path, httpx_mock):
+        """flag() raises RemoteError when remote rejects a non-local unit."""
+        httpx_mock.add_response(json={"detail": "not found"}, status_code=404)
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        with pytest.raises(RemoteError):
+            c.flag("ku_remote123", FlagReason.STALE, tier=Tier.PRIVATE)
+        c.close()
+
+    def test_confirm_raises_key_error_when_remote_unreachable_for_non_local(self, tmp_path: Path, httpx_mock):
+        """confirm() raises KeyError when remote is unreachable for non-local unit."""
+        httpx_mock.add_exception(httpx.ConnectError("Connection refused"))
+
+        c = Client(addr="http://unreachable", local_db_path=tmp_path / "test.db")
+        with pytest.raises(KeyError, match="ku_remote123"):
+            c.confirm("ku_remote123", tier=Tier.PRIVATE)
+        c.close()
+
+    def test_flag_raises_key_error_when_remote_unreachable_for_non_local(self, tmp_path: Path, httpx_mock):
+        """flag() raises KeyError when remote is unreachable for non-local unit."""
+        httpx_mock.add_exception(httpx.ConnectError("Connection refused"))
+
+        c = Client(addr="http://unreachable", local_db_path=tmp_path / "test.db")
+        with pytest.raises(KeyError, match="ku_remote123"):
+            c.flag("ku_remote123", FlagReason.STALE, tier=Tier.PRIVATE)
+        c.close()
+
+    def test_confirm_local_ignores_remote_rejection(self, tmp_path: Path, httpx_mock):
+        """confirm() succeeds locally even when remote rejects."""
+        from cq.models import Insight, create_knowledge_unit
+
+        httpx_mock.add_response(json={"detail": "rejected"}, status_code=400)
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        unit = create_knowledge_unit(domain=["api"], insight=Insight(summary="S", detail="D", action="A"))
+        c._store.insert(unit)
+
+        confirmed = c.confirm(unit.id)
+        assert confirmed.evidence.confidence == pytest.approx(0.6)
+        c.close()
+
+    def test_flag_local_ignores_remote_rejection(self, tmp_path: Path, httpx_mock):
+        """flag() succeeds locally even when remote rejects."""
+        from cq.models import Insight, create_knowledge_unit
+
+        httpx_mock.add_response(json={"detail": "rejected"}, status_code=400)
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        unit = create_knowledge_unit(domain=["api"], insight=Insight(summary="S", detail="D", action="A"))
+        c._store.insert(unit)
+
+        flagged = c.flag(unit.id, FlagReason.STALE)
+        assert flagged.evidence.confidence == pytest.approx(0.35)
         c.close()
 
 


### PR DESCRIPTION
## Summary
- Add `tier` keyword parameter to `confirm()` and `flag()` so callers route explicitly by provenance instead of requiring a local copy.
- Update `_remote_confirm()` and `_remote_flag()` to return the confirmed/flagged `KnowledgeUnit` from the response and raise `RemoteError` on rejection, matching `_remote_propose()`.
- Add 10 tests covering remote routing, rejection, unreachable, misconfiguration, and local-ignores-remote-rejection paths.

Fixes #10

## Test plan
- [x] 264 tests pass (`make test`)
- [x] Lint clean (`make lint`)
- [x] New tests cover: remote happy path, `RemoteError` on rejection, `KeyError` on unreachable, `RuntimeError` without remote, local path ignores remote rejection