### PR TITLE
Fix propose() to accept multiple languages and frameworks

### DIFF
--- a/src/cq/client.py
+++ b/src/cq/client.py
@@ -117,8 +117,8 @@ class Client:
         action: str,
         domains: list[str],
         *,
-        language: str | None = None,
-        framework: str | None = None,
+        languages: list[str] | None = None,
+        frameworks: list[str] | None = None,
         pattern: str = "",
         created_by: str = "",
     ) -> KnowledgeUnit:
@@ -129,8 +129,8 @@ class Client:
         if the remote explicitly rejects the unit.
         """
         context = Context(
-            languages=[language] if language else [],
-            frameworks=[framework] if framework else [],
+            languages=languages or [],
+            frameworks=frameworks or [],
             pattern=pattern,
         )
         unit = create_knowledge_unit(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -91,17 +91,29 @@ class TestLocalOnlyMode:
             )
             assert c.query(["testing"])[0].id == ku.id
 
-    def test_propose_with_language_and_framework(self, client: Client):
+    def test_propose_with_single_language_and_framework(self, client: Client):
         ku = client.propose(
             summary="Use Django ORM",
             detail="Better than raw SQL.",
             action="Use QuerySet API.",
             domains=["databases"],
-            language="python",
-            framework="django",
+            languages=["python"],
+            frameworks=["django"],
         )
         assert ku.context.languages == ["python"]
         assert ku.context.frameworks == ["django"]
+
+    def test_propose_with_multiple_languages_and_frameworks(self, client: Client):
+        ku = client.propose(
+            summary="Cross-language insight",
+            detail="Applies to both Python and Go.",
+            action="Check both implementations.",
+            domains=["api"],
+            languages=["python", "go"],
+            frameworks=["fastapi", "grpc"],
+        )
+        assert ku.context.languages == ["python", "go"]
+        assert ku.context.frameworks == ["fastapi", "grpc"]
 
     def test_confirm_non_local_without_remote_raises(self, client: Client):
         with pytest.raises(RuntimeError, match="remote API"):
@@ -117,14 +129,14 @@ class TestLocalOnlyMode:
             detail="Detail.",
             action="Action.",
             domains=["api"],
-            language="python",
+            languages=["python"],
         )
         client.propose(
             summary="Go insight",
             detail="Detail.",
             action="Action.",
             domains=["api"],
-            language="go",
+            languages=["go"],
         )
         results = client.query(["api"], language="python")
         assert len(results) == 2
@@ -138,7 +150,7 @@ class TestFullLifecycle:
             detail="Check error.code, not error.type.",
             action="Handle card_declined explicitly.",
             domains=["api", "stripe"],
-            language="python",
+            languages=["python"],
         )
 
         results = client.query(["api", "stripe"], language="python")


### PR DESCRIPTION
## Summary

- `Client.propose()` now accepts `languages: list[str]` and `frameworks: list[str]`, matching the proto `Context` message which defines both as `repeated string`.
- The old singular `language`/`framework` parameters are removed.

## Context

The proto `Context` message supports multiple languages and frameworks on a knowledge unit, but `propose()` artificially narrowed the interface to a single value for each. This made it impossible to tag a KU with e.g. both Python and Go.

A separate issue (mozilla-ai/cq-proto#2) tracks updating `QueryRequest` to also support repeated language/framework fields.

## Test plan

- [x] New test: propose with multiple languages and frameworks
- [x] Updated test: propose with single language and framework still works
- [x] All 265 tests pass
- [x] Lint clean